### PR TITLE
Fix leaving messages not showing up the username

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -15,7 +15,6 @@ function sendSystemMessage(template, member) {
     const channel = member.guild.channels.resolve(config.system_channel);
     if (channel && channel.type == "text") {
         channel.send(template
-                        .replace("$ID", member.id)
                         .replace("$NICKNAME", member.nickname)
                         .replace("$USERNAME", member.user.username)
                         .replace("$TAG", member.user.tag)

--- a/config.json.example
+++ b/config.json.example
@@ -5,6 +5,6 @@
         "some_name\\d\\d" // Will be converted to regex (case-insensitive)
     ],
     "join_message": "<@$ID> has arrived.", // Optional. Valid substitutions: $ID, $NICKNAME, $USERNAME, $TAG
-    "leave_message": "Goodbye, <@$ID>.", // Optional (see above)
+    "leave_message": "Goodbye, **$TAG**.", // Optional (see above)
     "system_channel": "531580498263408671" // Channel ID in which to send join and leave messages. Valid text channel required if using system messages.
 }


### PR DESCRIPTION
Things added/changed:

- Fix leaving messages not showing up the username.

This is how it currently looks.

![image](https://user-images.githubusercontent.com/51391473/128412654-e74abf8b-3727-4b1e-b4fd-f1b4b99feffa.png)

Tested with another bot, this is how it looks with this PR.

![image](https://user-images.githubusercontent.com/51391473/128413255-22c3c435-953c-4284-bd01-6d5ea59fae1f.png)

> This is because the event [`guildMemberRemove`](https://discord.js.org/#/docs/main/stable/class/Client?scrollTo=e-guildMemberRemove) emits a [`GuildMember`](https://discord.js.org/#/docs/main/stable/class/GuildMember) object. Since the user has already left the server (and therefore, is no longer a `GuildMember`), the ping does not work. **[@raklaptudirm](https://github.com/raklaptudirm)'s quote.**
